### PR TITLE
Fix guest addition install on vagrant 1.8.6 and virtualbox 5.1.8.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,8 +54,8 @@ Host software
 
 The software has been tested using:
 
-- VirtualBox 5.0.12
-- Vagrant 1.8.1
+- VirtualBox 5.1.8
+- Vagrant 1.8.6
 - Python 2.7
 
   - boto3 1.2.3

--- a/scripts/export-vmdk.sh
+++ b/scripts/export-vmdk.sh
@@ -100,9 +100,9 @@ umount $MNT
 
 # Install VirtualBox rpm to run VBoxManage convertdd
 # Warnings about compiling vboxdrv kernel module are expected
-wget http://download.virtualbox.org/virtualbox/5.0.10/VirtualBox-5.0-5.0.10_104061_el6-1.x86_64.rpm
-echo "70f4d9e54674cebca21e4332b18ce137 VirtualBox-5.0-5.0.10_104061_el6-1.x86_64.rpm" | md5sum -c /dev/stdin
-rpm -i --nodeps VirtualBox-5.0-5.0.10_104061_el6-1.x86_64.rpm
+wget http://download.virtualbox.org/virtualbox/5.1.8/VirtualBox-5.1-5.1.8_111374_el6-1.x86_64.rpm
+echo "756149c11f4cab8f72648c6a3c9e51e7 VirtualBox-5.1-5.1.8_111374_el6-1.x86_64.rpm" | md5sum -c /dev/stdin
+rpm -i --nodeps VirtualBox-5.1-5.1.8_111374_el6-1.x86_64.rpm
 
 VBoxManage convertdd "${device}" "${vmdk}" --format VMDK
 chmod 644 "${vmdk}"

--- a/scripts/install-guest-additions.sh
+++ b/scripts/install-guest-additions.sh
@@ -19,23 +19,37 @@ vagrant plugin list | grep vagrant-vbguest || vagrant plugin install vagrant-vbg
 # Create temporary vagrant directory.
 export VAGRANT_CWD="$(mktemp -d -t "${name}")"
 
+# Register base box.
+vagrant box add --name "${name}" "${box}"
+
+# Install security updates.
+# Install compiler and kernel headers required for building guest additions.
 cat >"${VAGRANT_CWD}/Vagrantfile" <<EOF
 Vagrant.configure(2) do |config|
   config.vm.box = "${name}"
   config.ssh.insert_key = false
+
+  # Do not attempt to install guest additions.
+  config.vbguest.auto_update = false
+  # Do not attempt to sync folder, dependent on guest additions.
+  config.vm.synced_folder ".", "/vagrant", disabled: true
+
   config.vm.provision :shell,
-    inline: "yum -y update --security"
+    inline: "yum -y update --security && yum -y install gcc kernel-devel"
 end
 EOF
-
-# Register base box.
-vagrant box add --name "${name}" "${box}"
-
-# Install guest additions, apply security updates.
 vagrant up
 vagrant halt
 
-# Install guest additions again in case of kernel security update.
+# Reboot in case of kernel security updates above.
+# Install guest additions.
+# Verify guest additions via default /vagrant synced folder mount.
+cat >"${VAGRANT_CWD}/Vagrantfile" <<EOF
+Vagrant.configure(2) do |config|
+  config.vm.box = "${name}"
+  config.ssh.insert_key = false
+end
+EOF
 vagrant up
 vagrant halt
 


### PR DESCRIPTION
Verify guest addition installation fixes of #6.

- Run vagrant without vbguest plugin to apply security updates and install the kernel headers
- Reboot to use new kernel if updated during security updates
- Run vagrant with vbguest plugin to install the guest

Test against vagrant 1.8.6 and virtualbox 5.1.8.
